### PR TITLE
avoid generation of unneccessary unzipped fastq files in the history

### DIFF
--- a/tools/cegr_statistics/input_dataset_r1_output_stats.xml
+++ b/tools/cegr_statistics/input_dataset_r1_output_stats.xml
@@ -25,7 +25,7 @@
         --output "$output"
     </command>
     <inputs>
-        <param name="input" type="data" format="fastqsanger" label="Fastqsanger input" />
+        <param name="input" type="data" format="fastqsanger.gz" label="Fastqsanger.gz input" />
     </inputs>
     <outputs>
         <data name="output" format="txt" />

--- a/tools/cegr_statistics/input_dataset_r2_output_stats.xml
+++ b/tools/cegr_statistics/input_dataset_r2_output_stats.xml
@@ -25,7 +25,7 @@
         --output "$output"
     </command>
     <inputs>
-        <param name="input" type="data" format="fastqsanger" label="Fastqsanger input" />
+        <param name="input" type="data" format="fastqsanger.gz" label="Fastqsanger.gz input" />
     </inputs>
     <outputs>
         <data name="output" format="txt" />


### PR DESCRIPTION
@dshao 
Would you please merge this to the master. This is the update to avoid generation of unzipped fastq files in the history, since fastq.gz is already there. As we tested for a number of sequencer runs, it is working fine